### PR TITLE
HP-1295: Fix Arbitrum ETH address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handle-sdk",
-  "version": "0.1.37",
+  "version": "0.1.39",
   "description": "handle.fi sdk",
   "main": "dist/src/index.js",
   "repository": "https://github.com/handle-fi/handle-sdk",

--- a/tokens/arbitrum.json
+++ b/tokens/arbitrum.json
@@ -3,7 +3,7 @@
     "symbol": "ETH",
     "name": "Ethereum",
     "decimals": 18,
-    "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
     "icon": "https://tokens.1inch.io/0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.png",
     "displayDecimals": 4
   },


### PR DESCRIPTION
Bump to 0.1.39 due to Anthony's WiP branch used 0.1.38.