### PR TITLE
removed need for tokenlist in convert

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handle-sdk",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "handle.fi sdk",
   "main": "dist/src/index.js",
   "repository": "https://github.com/handle-fi/handle-sdk",

--- a/src/components/Convert/Convert.ts
+++ b/src/components/Convert/Convert.ts
@@ -5,7 +5,6 @@ import routes from "./routes";
 import { WeightInput } from "./routes/weights";
 import { TokenInfo } from "@uniswap/token-lists";
 import { CHAIN_ID_TO_NETWORK_NAME } from "../../constants";
-import TokenManager from "../TokenManager";
 import { getNetworkFromSignerOrProvider } from "../../utils/general-utils";
 
 type ConvertRouteArgs = {
@@ -52,23 +51,6 @@ export type Quote = {
 };
 
 export default class Convert {
-  protected static tokenList: TokenInfo[] | undefined = undefined;
-
-  public static loadTokens = async () => {
-    const tokenManager = new TokenManager();
-    await tokenManager.initialLoad;
-    Convert.tokenList = tokenManager.getLoadedTokens();
-  };
-
-  public static getTokenList = async (): Promise<TokenInfo[]> => {
-    if (!Convert.tokenList) {
-      await Convert.loadTokens();
-    }
-
-    // token list will be loaded by now, so it is not undefined
-    return Convert.tokenList!;
-  };
-
   private static getHighestWeightRoute = async (weightInfo: WeightInput) => {
     const weightedRoutes = await Promise.all(
       routes.map((route) =>
@@ -111,8 +93,6 @@ export default class Convert {
   };
 
   public static getQuote = async (input: ConvertQuoteInput): Promise<Quote> => {
-    if (!this.tokenList) await this.loadTokens();
-
     const network = await Convert.getValidatedNetwork(
       input.fromToken,
       input.toToken,
@@ -136,8 +116,6 @@ export default class Convert {
   public static getSwap = async (
     input: ConvertTransactionInput
   ): Promise<ethers.PopulatedTransaction> => {
-    if (!this.tokenList) await this.loadTokens();
-
     const network = await Convert.getValidatedNetwork(input.fromToken, input.toToken, input.signer);
 
     const route = await this.getHighestWeightRoute({

--- a/src/components/Convert/getApiFeeAsPercentage.ts
+++ b/src/components/Convert/getApiFeeAsPercentage.ts
@@ -1,5 +1,5 @@
 import config from "../../config";
-import Convert from "./Convert";
+import TokenManager from "../TokenManager";
 
 export const getApiFeeAsPercentage = async (
   sellTokenAddress: string,
@@ -9,15 +9,15 @@ export const getApiFeeAsPercentage = async (
   const STABLE_TO_STABLE_FEE = 0.1;
   const NON_STABLE_FEE = 0.3;
 
-  const tokenList = await Convert.getTokenList();
+  const tokenList = new TokenManager();
+  await tokenList.initialLoad;
 
-  const sellToken = tokenList.find(
-    (token) => token.address.toLowerCase() === sellTokenAddress.toLowerCase()
-  );
-
-  const buyToken = tokenList.find(
-    (token) => token.address.toLowerCase() === buyTokenAddress.toLowerCase()
-  );
+  const sellToken = tokenList
+    .getLoadedTokens()
+    .find((token) => token.address.toLowerCase() === sellTokenAddress.toLowerCase());
+  const buyToken = tokenList
+    .getLoadedTokens()
+    .find((token) => token.address.toLowerCase() === buyTokenAddress.toLowerCase());
 
   if (buyToken?.address === config.forexAddress) {
     return 0;

--- a/src/components/TokenManager/index.ts
+++ b/src/components/TokenManager/index.ts
@@ -10,7 +10,7 @@ type TokenListCache = {
 export const DEFAULT_TOKEN_LIST_URLS: string[] = [
   "https://api-polygon-tokens.polygon.technology/tokenlists/default.tokenlist.json", // polygon
   "https://bridge.arbitrum.io/token-list-42161.json", // arbitrum
-  "https://api.coinmarketcap.com/data-api/v3/uniswap/all.json" // ethereum
+  "https://wispy-bird-88a7.uniswap.workers.dev/?url=http://tokens.1inch.eth.link" // ethereum
 ];
 
 type SearchTokenAddress = {


### PR DESCRIPTION
resolves #157 

Note the default tokenlist for ethereum was changed, as there were CORS errors when fetching the old tokenlist. These errors did not occur when fetching any other token list, leading me to believe the error is on their end (also CORS errors are serverside regardless). 